### PR TITLE
Mark hardware security services as out of scope

### DIFF
--- a/DeviceAPICharter.html
+++ b/DeviceAPICharter.html
@@ -103,6 +103,8 @@ to create client-side APIs that enable the development of Web Applications that 
 <p>The scope of this Working Group is this creation of API specifications for a
 device’s services that can be exposed to Web applications. Services include sensors, media capture, network information and discovery, and possibly application level services like calendar, contacts etc. Devices in this context include desktop computers, laptop computers, mobile Internet devices (MIDs), cellular phones, TVs, cameras and other connected devices.</p>
 
+<p>Hardware security services are out of scope for this group.</p>
+
 <p>Priority will be given to developing simple and consensual APIs, leaving
 more complex features to future versions.</p>
 


### PR DESCRIPTION
from W3C management review
separate group expected on hardware secure services
