### PR TITLE
Fix #41: Rename group to 'Devices and Sensors Working Group'

### DIFF
--- a/DeviceAPICharter.html
+++ b/DeviceAPICharter.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-US" lang="en-US">
 <head>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-  <title>[DRAFT] Device and Sensors Working Group Charter</title>
+  <title>[DRAFT] Devices and Sensors Working Group Charter</title>
   <link rel="stylesheet" href="https://www.w3.org/2005/10/w3cdoc.css"
   type="text/css" media="screen" />
   <link rel="stylesheet" type="text/css"
@@ -46,14 +46,14 @@
 <p><a href="https://www.w3.org/"><img alt="W3C"
 src="https://www.w3.org/Icons/w3c_home.png" height="48" width="72" /></a> </p>
 
-<h1 id="title">[DRAFT] Device and Sensors Working Group Charter</h1>
+<h1 id="title">[DRAFT] Devices and Sensors Working Group Charter</h1>
 
 <p><em>This is a draft revised Device and Sensors Working Group charter for discussion. It has no standing. See also the <a href="https://www.w3.org/2016/03/device-sensors-wg-charter.html">charter under which the Device and Sensors Working Group</a> currently operates.</em></p>
 
-<p class="mission">The mission of the <a href="https://www.w3.org/2009/dap/">Device and Sensors Working Group</a> is
+<p class="mission">The mission of the <a href="https://www.w3.org/2009/dap/">Devices and Sensors Working Group</a> is
 to create client-side APIs that enable the development of Web Applications that interact with device hardware and sensors such as the camera, microphone, and motion sensors.</p>
 
-<p><a href="https://www.w3.org/2004/01/pp-impl/43696/join">Join the Device and Sensors Working Group</a>.</p>
+<p><a href="https://www.w3.org/2004/01/pp-impl/43696/join">Join the Devices and Sensors Working Group</a>.</p>
 
 <table class="summary-table">
   <tbody>
@@ -81,7 +81,7 @@ to create client-side APIs that enable the development of Web Applications that 
 <div id="goals">
 <h2>Goals</h2>
 
-<p>The Device and Sensors Working Group aims at producing Web client-side APIs that facilitate deeper integration of Web applications into advanced capabilities of their host devices.</p>
+<p>The Devices and Sensors Working Group aims at producing Web client-side APIs that facilitate deeper integration of Web applications into advanced capabilities of their host devices.</p>
 
 <p>These capabilities include access to a camera, microphone, or system information such as network connection and battery level.</p>
 
@@ -158,7 +158,7 @@ the continued relevance and usefulness of the specifications it produces. </p>
   <dt><a href="https://www.w3.org/TR/orientation-event/">DeviceOrientation Event specification</a></dt>
   <dd><p>An event-based API that provides information about the physical orientation and motion of a hosting device</p>
     <p><strong>Draft state</strong>: Candidate Recommendation</p>
-    <p><strong>Adopted Candidate Recommendation</strong>: <a href="https://www.w3.org/TR/2016/CR-orientation-event-20160818/">DeviceOrientation Event Specification, W3C Candidate Recommendation 18 August 2016</a>. This API was formerly developed by the former Geolocation Working Group. The Device and Sensors Working Group intends to fix remaining known issues and to finish its progress on the Recommendation track.</p>
+    <p><strong>Adopted Candidate Recommendation</strong>: <a href="https://www.w3.org/TR/2016/CR-orientation-event-20160818/">DeviceOrientation Event Specification, W3C Candidate Recommendation 18 August 2016</a>. This API was formerly developed by the former Geolocation Working Group. The Devices and Sensors Working Group intends to fix remaining known issues and to finish its progress on the Recommendation track.</p>
     <p><strong>Reference Draft</strong>: <a href="https://www.w3.org/TR/2016/CR-orientation-event-20160818/">DeviceOrientation Event Specification, W3C Candidate Recommendation 18 August 2016</a>, published at <code>https://www.w3.org/TR/2016/CR-orientation-event-20160818/</code>, produced under <strong><a href="https://www.w3.org/2014/04/geo-charter.html">2014-2017 Geolocation Working Group charter</a></strong>.</p></dd>
 <dt>Geolocation Sensor</dt>
   <dd><p>An API for obtaining geolocation reading from the hosting device, based on the Generic Sensor API</p>
@@ -236,7 +236,7 @@ href="https://www.w3.org/2009/dap/">group home page</a></em>.</p>
       href="https://www.w3.org/TR/WebIDL/">Web IDL</a></cite>, and <cite><a
       href="https://www.w3.org/TR/FileAPI/">File API</a></cite>.</dd>
   <dt><a href="/2011/04/webrtc/">Web Real Time Communications Working Group</a></dt>
-<dd>Both the Device and Sensors and WebRTC Working Groups develop capture-related APIs.</dd>
+<dd>Both the Devices and Sensors and WebRTC Working Groups develop capture-related APIs.</dd>
 </dl>
 
 <div>
@@ -287,7 +287,7 @@ consideration upon their agreement to the terms of the <a href="https://www.w3.o
 
 <p>Information about the group (for example, details about deliverables,
 issues, actions, status, participants) is available from the <a
-href="https://www.w3.org/2009/dap/">Device and Sensors Working Group
+href="https://www.w3.org/2009/dap/">Devices and Sensors Working Group
 home page.</a> </p>
 
 <p>The Working Group’s Teleconferences focus on discussion of particular
@@ -423,7 +423,7 @@ the W3C Process, the W3C Process shall take precedence. </p>
 
 <hr />
 <address>
-  Editor: <a href="/People/Dom/">Dominique Hazael-Massieux</a>, Team Contact, based on the <a href="https://www.w3.org/2011/07/DeviceAPICharter">previous Device and Sensors (then called Device APIs) Working Group’s charter</a>
+  Editor: <a href="/People/Dom/">Dominique Hazael-Massieux</a>, Team Contact, based on the <a href="https://www.w3.org/2011/07/DeviceAPICharter">previous Devices and Sensors (then called Device APIs) Working Group’s charter</a>
 </address>
 </div>
 


### PR DESCRIPTION
Use the plular form 'Devices' over singular to align the formal
name with the name people actually use to refer to the group.

(Where we refer to the current charter, we use the singular form.)

PTAL @dontcallmedom 