### PR TITLE
Rename 'browser context' -> 'browsing context'

### DIFF
--- a/DeviceAPICharter.html
+++ b/DeviceAPICharter.html
@@ -106,7 +106,7 @@ more complex features to future versions.</p>
 <p>To advance to Proposed Recommendation, each specification is expected to
 have two independent implementations of all features defined in the
 specification, including implementation on a constrained device (e.g. mobile phone, TV).</p>
-<p>APIs that cannot be demonstrated to be implementable securely within the default browser context will not be released.</p>
+<p>APIs that cannot be demonstrated to be implementable securely within the default browsing context will not be released.</p>
 
 
 <p>Each specification should contain a section detailing any known


### PR DESCRIPTION
Reference the term defined in the HTML spec for clarify.

PTAL @dontcallmedom 