### PR TITLE
Add end date

### DIFF
--- a/DeviceAPICharter.html
+++ b/DeviceAPICharter.html
@@ -59,7 +59,7 @@ to create client-side APIs that enable the development of Web Applications that 
   <tbody>
     <tr id="Duration">
       <th rowspan="1" colspan="1">End date</th>
-      <td rowspan="1" colspan="1"><span class="todo">YYYY-MM-DD</span></td>
+      <td rowspan="1" colspan="1"><span>2020-03-31</span></td>
     </tr>
     <tr>
       <th rowspan="1" colspan="1">Chairs</th>


### PR DESCRIPTION
Plan for a two-year charter, ending 31 March 2020, as proposed by @samuelweiler.