### PR TITLE
Add Web Share API to Deliverables

### DIFF
--- a/DeviceAPICharter.html
+++ b/DeviceAPICharter.html
@@ -238,7 +238,7 @@ above.</p>
     <p><strong>Draft State:</strong> <a href="https://wicg.github.io/netinfo/">Adopted from WICG</a> (see also <a href="https://www.w3.org/TR/netinfo-api/">Working Group Note</a> that predates the WICG Draft Report)</p>
   </dd>
   <dt id="web-share">Web Share API</dt>
-  <dd> An API for sharing text, links and other content to an arbitrary destination of the user's choice
+  <dd>An API for sharing text and URLs with other websites and device's built-in services and applications of the user's choice
     <p><strong>Draft State:</strong> <a href="https://wicg.github.io/web-share/">Adopted from WICG</a> (see also <a href="https://www.w3.org/TR/web-intents/">Web Intents Working Group Note</a> that predates the WICG Draft Report)</p>
   </dd>
 </dl>

--- a/DeviceAPICharter.html
+++ b/DeviceAPICharter.html
@@ -51,7 +51,7 @@ src="https://www.w3.org/Icons/w3c_home.png" height="48" width="72" /></a> </p>
 <p><em>This is a draft revised Device and Sensors Working Group charter for discussion. It has no standing. See also the <a href="https://www.w3.org/2016/03/device-sensors-wg-charter.html">charter under which the Device and Sensors Working Group</a> currently operates.</em></p>
 
 <p class="mission">The mission of the <a href="https://www.w3.org/2009/dap/">Devices and Sensors Working Group</a> is
-to create client-side APIs that enable the development of Web Applications that interact with device hardware and sensors such as the camera, microphone, and motion sensors.</p>
+to create client-side APIs that enable the development of Web Applications that interact with device hardware, services, and sensors such as the camera, microphone, and motion sensors.</p>
 
 <p><a href="https://www.w3.org/2004/01/pp-impl/43696/join">Join the Devices and Sensors Working Group</a>.</p>
 
@@ -236,6 +236,10 @@ above.</p>
   <dt id="network">Network Information API</dt>
   <dd>An API to discover the current network characteristics — the group will determine in collaboration with the WICG whether the existing implementations of this API on mobile warrants restarting its standardization process
     <p><strong>Draft State:</strong> <a href="https://wicg.github.io/netinfo/">Adopted from WICG</a> (see also <a href="https://www.w3.org/TR/netinfo-api/">Working Group Note</a> that predates the WICG Draft Report)</p>
+  </dd>
+  <dt id="web-share">Web Share API</dt>
+  <dd> An API for sharing text, links and other content to an arbitrary destination of the user's choice
+    <p><strong>Draft State:</strong> <a href="https://wicg.github.io/web-share/">Adopted from WICG</a> (see also <a href="https://www.w3.org/TR/web-intents/">Web Intents Working Group Note</a> that predates the WICG Draft Report)</p>
   </dd>
 </dl>
 


### PR DESCRIPTION
Re-reading the [new draft Charter][1], I feel the [Web Share API][2] fits within the scope with just minor amendment to the mission statement to bring back the word "services" present in the [current Charter][3].

I expanded the API abstract a bit, since I feel "arbitrary destination" may raise questions and we should be more specific instead with regard to [possible share targets][4].

I also noted Web Intents as a historical pointer.

PTAL @xfq @samuelweiler @dontcallmedom 

FYI @mgiuca @marcoscaceres

Fixes #57.

[1]: https://w3c.github.io/dap-charter/DeviceAPICharter.html
[2]: https://wicg.github.io/web-share/
[3]: https://www.w3.org/2016/03/device-sensors-wg-charter.html
[4]: https://wicg.github.io/web-share/#examples-of-share-targets