### PR TITLE
accessiblity/privacy requirements

### DIFF
--- a/DeviceAPICharter.html
+++ b/DeviceAPICharter.html
@@ -82,13 +82,22 @@ src="https://www.w3.org/Icons/w3c_home.png" height="48" width="72" /></a> </p>
 <div id="goals">
 <h2>Goals</h2>
 
-<p>The Devices and Sensors Working Group produces Web client-side APIs that allow Web applications to access advanced capabilities of their host devices.</p>
+<p>The Devices and Sensors Working Group produces Web client-side APIs that allow Web applications to
+  access advanced capabilities of their host devices.</p>
 
-<p>These capabilities include access to cameras, microphones, and system information such as network connection and battery level.</p>
+<p>These capabilities include access to cameras, microphones, and system information such as network
+  connection and battery level.</p>
 
-<p>Adding these advanced features to the Web environment empowers Web developers to create richer and more context-aware Web applications.</p>
+<p>Adding these advanced features to the Web environment empowers Web developers to create richer and
+  more context-aware Web applications.</p>
 
-<p>Given the sensitive nature of the data and sensors to which these APIs grant access, these APIs must be both secure and privacy-enabling by design, based on the current Web browser security model. When existing browser-based privacy and security metaphors apply, the WG will endeavour to reuse them. When those metaphors do not apply, the WG will explore innovative security and privacy mechanisms.</p>
+<p>These APIs grant access to sensitive data, some of which is not
+  intuitively obvious as being sensitive, and some of which can be used
+  to track users.  Because of that, these APIs
+  must be both secure and privacy-enabling by design, based on the current Web browser security
+  model. When existing browser-based privacy and security metaphors apply, the WG will endeavour
+  to reuse them. When those metaphors do not apply, the WG will explore innovative security and
+  privacy mechanisms.</p>
 </div>
 
 <div class="scope">
@@ -105,21 +114,28 @@ more complex features to future versions.</p>
 <h3>Success Criteria</h3>
 
 <p>To advance to Proposed Recommendation, each specification must
-have two independent implementations of all defined features, at least one of which is
+  have two independent implementations of all defined features, at least one of which is
   on a constrained device such as a mobile phone or TV.</p>
-<p>APIs that cannot be demonstrated to be implementable securely within the default browser context will not be released.</p>
+  
+<p>Comprehensive test suites will be developed for each specification to ensure interoperability,
+  and the group will create interoperability reports. The group will also maintain errata as
+  required for the continued relevance and usefulness of the specifications it produces. </p>  
 
+<p>Each specification must contain a section on accessibility that describes the
+  benefits and impacts, including ways specification features can be used to address
+  them, and recommendations for maximising accessibility in implementations.</p>
 
-<p>Each specification must contain a section detailing any known
-  security or privacy implications for implementers, Web authors, and end users.</p>
+<p>Each specification must detail all known security and privacy implications for
+  implementers, Web authors, and end users.</p>
 
-<p>Additionally, comprehensive test suites will be developed for each
-specification to ensure interoperability, and the group will create
-interoperability reports. The group will also maintain errata as required for
-the continued relevance and usefulness of the specifications it produces. </p>
+<p>APIs that cannot be demonstrated to be implementable securely within the default browser
+  context will not be released.</p>
 
-<p>Where applicable, each specification should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and recommendations for maximising accessibility in implementations.</p>
-
+<p>The specifications produced by this WG must mitigate disclosure of data when possible
+  and seek meaningful user consent in other cases.  If the WG decides that one or more of
+  its specifications cannot be usefully implemented while simultaneously allowing users to
+  meaningfully consent to the use of sensitive data, it may decide to not advance those
+  specifications.</p>
 
 </div>
 


### PR DESCRIPTION
per reviewer comments.  Reorders "success criteria" section to make accessibility more obvious.  Make privacy AND security section(s)... detail ALL issues (v. or/any).  Add the option to not publish/advance if privacy/consent cannot be achieved.