### PR TITLE
Editorial and typo fixes

### DIFF
--- a/DASCharter-2020.html
+++ b/DASCharter-2020.html
@@ -164,7 +164,7 @@
           sensitive data will define normative mitigations to address any
           known security and privacy threats. These mitigations are developed
           and reviewed together with the security and privacy community and
-          incorporated normatively into the respectively specifications. In
+          incorporated normatively into the respective specifications. In
           addition, the WG produces non-normative security and privacy
           explainers that describe concrete best practices, design patterns,
           and mitigation strategies that cater to web developers to raise
@@ -176,7 +176,7 @@
           their functionality and data exposure to the minimum required to
           implement real-world use cases adhering to the principles of data
           minimization. Applicability of mitigation strategies such as data
-          quantization and permissions grants will be assessed on a use case
+          quantization and permissions grants will be assessed on a use-case
           basis considering the requirements derived from real-world use cases.
         </p>
         <p>
@@ -355,7 +355,7 @@
           </dt>
           <dd>
             <p>
-              An API to monitor changes in acceleration in the device's three
+              An API to monitor acceleration in the device's three
               primary axes
             </p>
             <p class="draft-status">
@@ -1057,7 +1057,7 @@
               change.
             </p>
             <p>
-              If testing is not practical due to web-platforms-tests
+              If testing is not practical due to web-platform-tests
               limitations, please explain why and if appropriate file an issue
               with the '<a href=
               "https://github.com/web-platform-tests/wpt/issues?utf8=%E2%9C%93&amp;q=label%3Atype%3Auntestable%20">type:untestable</a>'


### PR DESCRIPTION
Accelerometer should description be " An API to monitor acceleration" rather than "changes in acceleration," as I don't think you're looking for the second derivative only.