### PR TITLE
Update DASCharter-2020.html 

### DIFF
--- a/DASCharter-2020.html
+++ b/DASCharter-2020.html
@@ -552,7 +552,7 @@
           Since HTML Media Capture extends the <a
           href="https://html.spec.whatwg.org/multipage/">HTML Living
           Standard</a>, the Working Group may propose to W3C to upstream the
-          spec when completed, to the WHATWG HTML LS for maintenance, as
+          spec, to the WHATWG HTML LS for maintenance, as
           anticipated by Section 10.2 of the <a
           href="https://www.w3.org/2019/04/WHATWG-W3C-MOU.html">Memorandum of
           Understanding Between W3C and WHATWG</a>.


### PR DESCRIPTION
I believe HTML Media Capture is already a W3C Recommendation (so remove "when completed").
W3C and WHATWG are discussing the terms of the proposed upstreaming.