### PR TITLE
Add a Tentative Deliverables section

### DIFF
--- a/DASCharter-2020.html
+++ b/DASCharter-2020.html
@@ -502,6 +502,9 @@
         <h3 id="tentative">
           Tentative Deliverables
         </h3>
+        <p>
+          Depending on the progress, the Group may also produce W3C Recommendations for the following documents:
+        </p>
         <dl>
           <dt>
             <a href=

--- a/DASCharter-2020.html
+++ b/DASCharter-2020.html
@@ -449,19 +449,6 @@
           </dd>
           <dt>
             <a href=
-            "https://github.com/SamsungInternet/Explainers/blob/master/Foldables/FoldState.md#angle-sensor-based-on-genericsensor-api">
-            Fold Angle Sensor</a>
-          </dt>
-          <dd>
-            <p>
-              An API to monitor the device’s fold angle
-            </p>
-            <p class="draft-status">
-              <b>Draft state:</b> Explainer
-            </p>
-          </dd>
-          <dt>
-            <a href=
             "https://www.w3.org/TR/orientation-event/">DeviceOrientation Event
             specification</a>
           </dt>
@@ -509,6 +496,24 @@
             <p>
               Produced under <b>Working Group Charter:</b> <a href=
               "https://www.w3.org/2018/06/devices-sensors-wg-charter.html">https://www.w3.org/2018/06/devices-sensors-wg-charter.html</a>
+            </p>
+          </dd>
+        </dl>
+        <h3 id="tentative">
+          Tentative Deliverables
+        </h3>
+        <dl>
+          <dt>
+            <a href=
+            "https://github.com/SamsungInternet/Explainers/blob/master/Foldables/FoldState.md#angle-sensor-based-on-genericsensor-api">
+            Fold Angle Sensor</a>
+          </dt>
+          <dd>
+            <p>
+              An API to monitor the device’s fold angle
+            </p>
+            <p class="draft-status">
+              <b>Draft state:</b> Explainer
             </p>
           </dd>
           <dt>


### PR DESCRIPTION
Move Screen Fold API and Network Information API to this section to clarify about the maturity status of them since they are under incubation, per discussions in the AB/TAG Experiment on the DAS formal objection.